### PR TITLE
Fix non-object diffing and general error handling

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const path = require('path');
+const util = require('util');
 
 const arg = require('arg');
 const chalk = require('chalk');
@@ -120,7 +121,27 @@ function stringifyReplacer(k, v) {
 	}
 }
 
+function indent(s) {
+	return s.replace(/(^|\r?\n)/g, '$1    ');
+}
+
+function inspect(o) {
+	return util.inspect(o, {depth: Number(process.env.BEST_DEPTH || 3)});
+}
+
 function coloredDiff(expected, actual) {
+	// Special case for non-object argument(s);
+	// otherwise, they look strange (issue #2)
+	if (typeof expected !== 'object' || typeof actual !== 'object') {
+		return chalk`{green {bold expected:}
+
+${indent(inspect(expected))}}
+
+{red {bold received:}
+
+${indent(inspect(actual))}}`;
+	}
+
 	// We invert the actual/expected and the colors
 	// so that the expected shows up first and the actual
 	// shows up second - this is why the colors don't look like
@@ -143,11 +164,17 @@ function coloredDiff(expected, actual) {
 function errorMessage(err) {
 	const parts = [];
 
+	if (err.stack) {
+		const stackLines = err.stack.split(/\r?\n/g).filter(line => /^\s{3,}at\s+/.test(line));
+		const firstLine = (stackLines[0] || '').trim();
+		if (firstLine) {
+			parts.push(chalk`{redBright ${firstLine}}\n`);
+		}
+	}
+
 	if (err.actual && err.expected) {
 		parts.push(coloredDiff(err.actual, err.expected));
 	}
-
-	parts.push(err.stack);
 
 	return parts.join('\n');
 }
@@ -168,7 +195,10 @@ async function runTest(name, fn) {
 	if (errResult) {
 		// Failed
 		message += chalk`{red.bold FAIL} {whiteBright ${name.substring(0, process.stdout.columns - 5)}}\n`;
-		message += chalk`{red ${errorMessage(errResult)}}\n\n`;
+		message += chalk`{red ${errorMessage(errResult)}\n}`;
+		if (args['--verbose']) {
+			message += chalk`\n{red ${errResult.stack || errResult.toString()}}\n\n`;
+		}
 	} else {
 		message += chalk`{green.bold PASS} {whiteBright ${name.substring(0, process.stdout.columns - 5)}}`;
 		if (args['--verbose']) {


### PR DESCRIPTION
Fixes #2.

Here is what it looked like before:

```javascript
assert.equal(3, 2);
```

![image](https://user-images.githubusercontent.com/885648/49955929-4d803500-ff04-11e8-89ba-f1abdf1fff74.png)

```javascript
assert.equal(3, {foo: 'bar'});
```

![image](https://user-images.githubusercontent.com/885648/49955952-5bce5100-ff04-11e8-886a-a348323b33bd.png)

and after:

```javascript
assert.equal(3, 2);
```

![image](https://user-images.githubusercontent.com/885648/49956037-87513b80-ff04-11e8-94f4-fa17dd4cd0b6.png)


```javascript
assert.equal(3, {foo: 'bar'});
```

![image](https://user-images.githubusercontent.com/885648/49956016-799bb600-ff04-11e8-8d71-2e224c56bbcb.png)


As a bonus, I included the error handling that honors `-v` a bit more. Here it is with object diffing:

![image](https://user-images.githubusercontent.com/885648/49956064-989a4800-ff04-11e8-9d16-d208cb3ff8ff.png)

And with `-v`, the stack is included below.

![image](https://user-images.githubusercontent.com/885648/49956081-a4860a00-ff04-11e8-9fc8-6ab597914686.png)

---

Let me know if the colors need tweaking. This is with iTerm2.