### PR TITLE
Allow the importing of all extensions supported by the environment

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -264,13 +264,15 @@ async function main() {
 	}
 
 	// Get file listing
+	const allowedExtensions = Object.getOwnPropertyNames(require.extensions);
+
 	const filePaths = (((args['--include'] || []).length > 0) ? args['--include'] : ['test']);
 	const files = (await globby(filePaths, {
 		expandDirectories: {
-			extensions: ['js']
+			extensions: allowedExtensions.map(s => s.replace(/^\.+/, ''))
 		}
 	})).filter(filepath => {
-		if (path.extname(filepath) !== '.js') {
+		if (!allowedExtensions.includes(path.extname(filepath))) {
 			warning(`ignoring file (not a script): ${filepath}`);
 			return false;
 		}


### PR DESCRIPTION
So the `--require` flag was a good idea but incredibly useless since we hardcoded in the extensions we allowed.

I instead added the extensions keys as possible extensions so that things like `--require coffeescript/register` would work.